### PR TITLE
Fix old to new link - readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
   <a href="https://badge.fury.io/js/%40human-internet%2Freact-native-humanid">
     <img src="https://badge.fury.io/js/%40human-internet%2Freact-native-humanid.svg" alt="npm version" />
   </a>
-  <a href="https://github.com/bluenumberfoundation/humanid-reactnative-sdk/blob/main/LICENSE">  
+  <a href="https://github.com/human-internet/humanid-reactnative-sdk/blob/main/LICENSE">  
     <img src="https://img.shields.io/badge/License-GPL%20v3-blue.svg" alt="license" />  
   </a>  
 </p>  


### PR DESCRIPTION
Simple link fix. 

Problem is also persistent on front end but can't find repo of this: https://developers.human-id.org/home/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the license link in the README to direct users to the correct repository, ensuring access to the latest licensing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->