### PR TITLE
feat: add new deeplink integration

### DIFF
--- a/lib/typescript/core/core.interface.d.ts
+++ b/lib/typescript/core/core.interface.d.ts
@@ -28,6 +28,7 @@ declare type onErrorCallback = () => void;
 declare type onSuccessCallback = (exchangeToken: string) => void;
 export interface MainComponentRef {
     logIn: () => void;
+    handleDeepLink: IHandleDeepLink;
 }
 export interface MainComponentProps {
     ref: (ref: MainComponentRef) => void;
@@ -37,6 +38,7 @@ export declare type IHumanIDProvider = React.FunctionComponent & {
     ref: MainComponentRef | null;
 };
 export declare type IConfigureHumanID = (options: ConfigureParams) => void;
+export declare type IHandleDeepLink = (deepLink: string, onSuccess: onSuccessCallback, onError: onErrorWithMessageCallback) => void;
 export declare type ILogIn = () => void;
 export declare type IOnCancel = (callback: onCancelCallback) => void;
 export declare type IOnError = (callback: onErrorCallback) => void;

--- a/lib/typescript/index.d.ts
+++ b/lib/typescript/index.d.ts
@@ -1,6 +1,7 @@
-import { IConfigureHumanID, ILogIn, IOnCancel, IOnError, IOnSuccess, IUnsubscribeAllEventListener } from './core/core.interface';
+import { IConfigureHumanID, IHandleDeepLink, ILogIn, IOnCancel, IOnError, IOnSuccess, IUnsubscribeAllEventListener } from './core/core.interface';
 import HumanIDProvider from './core/Provider';
 declare const configureHumanID: IConfigureHumanID;
+declare const handleDeepLink: IHandleDeepLink;
 declare const logIn: ILogIn;
 declare const onCancel: IOnCancel;
 declare const onSuccess: IOnSuccess;

--- a/src/core/core.interface.ts
+++ b/src/core/core.interface.ts
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import {FlagType} from '../modules/Login/Login.interface';
 
 export interface UseGlobalState {
@@ -16,26 +18,30 @@ export interface UseGlobalState {
   clearState: () => void;
 }
 
-import React from 'react';
 
 export interface ConfigureParams {
   clientId: string;
   clientSecret: string;
+  appExtId: string;
 }
 
 export interface Options {
   clientId: string;
   clientSecret: string;
+  appExtId: string;
 }
 
 type onCancelCallback = () => void;
 
 type onErrorCallback = () => void;
 
+type onErrorWithMessageCallback = (error: string) => void;
+
 type onSuccessCallback = (exchangeToken: string) => void;
 
 export interface MainComponentRef {
   logIn: () => void;
+  handleDeepLink: IHandleDeepLink;
 }
 
 export interface MainComponentProps {
@@ -54,6 +60,8 @@ export type IHumanIDProvider = React.FunctionComponent & {
 export type IConfigureHumanID = (options: ConfigureParams) => void;
 
 export type ILogIn = () => void;
+
+export type IHandleDeepLink = (deepLink: string, onSuccess: onSuccessCallback, onError: onErrorWithMessageCallback) => void;
 
 export type IOnCancel = (callback: onCancelCallback) => void;
 

--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -3,6 +3,7 @@ import {Options} from './core.interface';
 const options: Options = {
   clientSecret: '',
   clientId: '',
+  appExtId: '',
 };
 
 export default options;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,25 +1,31 @@
+import HumanIDProvider from './core/Provider';
+import Toast from './modules/Toast'
+import options from './core/options';
+import {EventRegister, ON_CANCEL, ON_ERROR, ON_SUCCESS} from './core/eventManager';
 import {
   IConfigureHumanID,
+  IHandleDeepLink,
   ILogIn,
   IOnCancel,
   IOnError,
   IOnSuccess,
   IUnsubscribeAllEventListener
 } from './core/core.interface';
-import {EventRegister, ON_CANCEL, ON_ERROR, ON_SUCCESS} from './core/eventManager';
-import options from './core/options';
-import HumanIDProvider from './core/Provider';
-import Toast from './modules/Toast'
 
 const configureHumanID: IConfigureHumanID = (params) => {
-  const {clientId, clientSecret} = params;
+  const {clientId, clientSecret, appExtId} = params;
 
   options.clientId = clientId;
   options.clientSecret = clientSecret;
+  options.appExtId = appExtId;
 };
 
 const logIn: ILogIn = () => {
   HumanIDProvider.ref?.logIn();
+};
+
+const handleDeepLink: IHandleDeepLink = (deepLink, onSuccess, onError) => {
+  HumanIDProvider.ref?.handleDeepLink(deepLink, onSuccess, onError);
 };
 
 const onCancel: IOnCancel = (callback) => {
@@ -58,6 +64,7 @@ const unsubscribeAllEventListeners: IUnsubscribeAllEventListener = () => {
 
 export {
   configureHumanID,
+  handleDeepLink,
   logIn,
   onError,
   onSuccess,

--- a/src/modules/MainComponent.tsx
+++ b/src/modules/MainComponent.tsx
@@ -59,7 +59,7 @@ const MainComponent: IMainComponent = (_props, ref): React.ReactElement => {
     try {
       setWebLoginModalVisible(true);
       let baseUrl = "https://api.human-id.org/v1/";
-      let endPointUrl = "mobile/users/web-login";
+      let endPointUrl = "mobile/users/web-login?web_login_version=v2";
       const response = await fetch(baseUrl + endPointUrl, {
         method: "POST",
         headers: {
@@ -123,7 +123,7 @@ const MainComponent: IMainComponent = (_props, ref): React.ReactElement => {
   React.useImperativeHandle(ref, () => ({
     logIn: () =>
       getWebLogin({
-        lang: "en",
+        lang: "en"
       }),
     handleDeepLink
   }));

--- a/src/string/label.ts
+++ b/src/string/label.ts
@@ -1,0 +1,5 @@
+export const HUMAN_ID_DEEPLINK_PREFIX = 'humanid-';
+export const HUMAN_ID_DEEPLINK_EXCHANGE_TOKEN_PREFIX = 'et=';
+export const HUMAN_ID_DEEPLINK_ERROR_PREFIX = 'error=';
+export const SUCCESFUL_LOGIN_MESSAGE = 'You’ve successfully logged in. Your data has been securely erased.'; 
+export const UNKNOWN_ERROR_MESSAGE = 'Unknown error';


### PR DESCRIPTION
This commit includes the following changes
1. Add `handleDeepLink` function. Users can use this function to parse their deeplink url. Based on the deeplink, they can get `onSuccess` or `onError` call
2. Add `appExtId` on `configureHumanId` function. This will read more precise deeplink so only app with the registered `appExtId` can get the callback.
3. Add `string` file for single location read.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced deep link handling functionality in the MainComponent, enhancing navigation to specific app content and providing user feedback during login operations.
	- Added an `appExtId` property to configuration options for improved integration capabilities.
	- Established standardized string constants for deep linking and user login messages.

- **Bug Fixes**
	- Enhanced error management for deep links with success and error handling mechanisms.
	
- **Documentation**
	- Updated public API to include new deep link handling methods and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->